### PR TITLE
Added double-quotes to postgres queries

### DIFF
--- a/src/ckanext-data-catalog-510/ckanext/data_catalog_510/controllers/database_handler.py
+++ b/src/ckanext-data-catalog-510/ckanext/data_catalog_510/controllers/database_handler.py
@@ -201,6 +201,8 @@ class SQLHandler:
             engine = create_engine(self.db_uri)
             if db_type == 'mysql':
                 query = f'Select Count(*) from `{schema}`.{table_name};'
+            elif db_type == 'postgres':
+                query = f'Select Count(*) from "{schema}"."{table_name}";'
             else:
                 query = f'Select Count(*) from {schema}.{table_name};'
             


### PR DESCRIPTION
Added double quotes to postgres queries to rectify errors for capital letters and symbols in the schema or table names.